### PR TITLE
small fix 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GasChromatographyTools"
 uuid = "b1a91d42-e520-41a6-b75d-584445aea833"
 authors = ["Jan Leppert <jleppert@uni-bonn.de>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Dierckx = "39dd38d3-220a-591b-8e3c-4c3a8c710a94"

--- a/src/GasChromatographyTools.jl
+++ b/src/GasChromatographyTools.jl
@@ -202,11 +202,11 @@ end
 Change the inital time and peak widths for the substances in a defined GC-system
 `par` to the values `init_τ` and `init_t`.
 """ 
-function change_initial(par::GasChromatographySimulator.Parameters, init_τ, init_t)
+function change_initial(par::GasChromatographySimulator.Parameters, init_t, init_τ)
 	# copys the parameters `par` and changes the values of par.sub[i].τ₀ and par.sub[i].t₀ to init_τ[i] resp. init_t[i]
 	newsub = Array{GasChromatographySimulator.Substance}(undef, length(par.sub))
 	for i=1:length(par.sub)
-		newsub[i] = GasChromatographySimulator.Substance(par.sub[i].name, par.sub[i].CAS, par.sub[i].Tchar, par.sub[i].θchar, par.sub[i].ΔCp, par.sub[i].φ₀, par.sub[i].ann, par.sub[i].Dag, init_τ[i], init_t[i])
+		newsub[i] = GasChromatographySimulator.Substance(par.sub[i].name, par.sub[i].CAS, par.sub[i].Tchar, par.sub[i].θchar, par.sub[i].ΔCp, par.sub[i].φ₀, par.sub[i].ann, par.sub[i].Dag, init_t[i], init_τ[i])
 	end
 	newpar = GasChromatographySimulator.Parameters(par.sys, par.prog, newsub, par.opt)
 	return newpar

--- a/src/GasChromatographyTools.jl
+++ b/src/GasChromatographyTools.jl
@@ -197,10 +197,10 @@ end
 
 #---misc-functions-----------------------------------------------------------------------------------
 """
-	change_initial(par, init_τ, init_t)
+	change_initial(par, init_t, init_τ)
 
 Change the inital time and peak widths for the substances in a defined GC-system
-`par` to the values `init_τ` and `init_t`.
+`par` to the values `init_t` and `, init_τ`.
 """ 
 function change_initial(par::GasChromatographySimulator.Parameters, init_t, init_τ)
 	# copys the parameters `par` and changes the values of par.sub[i].τ₀ and par.sub[i].t₀ to init_τ[i] resp. init_t[i]


### PR DESCRIPTION
- changed the order of `init_τ`, `init_t` to `init_t`, `init_τ`in the argument of the function `change_initial(par, init_t, init_τ)` to be consistent with the definition of `GasChromatographySimulator(Substance(name, CAS, Tchar, θchar, ΔCp, φ₀, ann, Dag, t₀, τ₀)`